### PR TITLE
matplotlib이 3.6.2보다 낮은걸 daam이 체크하게 하는 풀 리퀘스트

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,3 +1,20 @@
 import launch
-if not launch.is_installed('matplotlib'):
-    launch.run_pip('install matplotlib==3.6.2', desc='Installing matplotlib==3.6.2')
+
+
+def check_matplotlib():
+    if not launch.is_installed("matplotlib"):
+        return False
+
+    try:
+        import matplotlib
+    except ImportError:
+        return False
+
+    if hasattr(matplotlib, "__version_info__"):
+        version = matplotlib.__version_info__
+        return version.major >= 3 and version.minor >= 6 and version.micro >= 2
+    return False
+
+
+if not check_matplotlib():
+    launch.run_pip("install matplotlib==3.6.2", desc="Installing matplotlib==3.6.2")


### PR DESCRIPTION
matplotlib에 __version_info__ 는 아마 3.5.0버전에 생긴걸로 보입니다.

실행전:
![Cap 2023-01-21 22-36-18-438](https://user-images.githubusercontent.com/37621276/213869627-652d6a6e-90eb-4af0-8e70-4fb8c99500a2.png)

실행후:
![Cap 2023-01-21 22-39-59-821](https://user-images.githubusercontent.com/37621276/213869633-d23c3dba-1ac7-49b2-970a-a70a36a6aa61.png)

됨

`packaging` 패키지의 `version.parse`를 쓰면 더 간단해지는데, 세상에 어떤 에러가 또 있을지 몰라 안썼습니다.