### PR TITLE
save heatmap to subfolder

### DIFF
--- a/scripts/daam_script.py
+++ b/scripts/daam_script.py
@@ -288,7 +288,9 @@ class Script(scripts.Script):
                             img : Image.Image = utils.image_overlay_heat_map(params.image, heat_map_img, alpha=self.alpha, caption=caption, image_scale=self.heatmap_image_scale)
 
                             fullfn_without_extension, extension = os.path.splitext(params.filename) 
-                            full_filename = fullfn_without_extension + "_" + attention +  ("_" + self.attn_captions[i] if self.attn_captions[i] else "") + extension
+                            if not os.path.exists(fullfn_without_extension):
+                                os.makedirs(fullfn_without_extension)
+                            full_filename = fullfn_without_extension + "/" + attention + ("_" + self.attn_captions[i] if self.attn_captions[i] else "") + extension
                             
                             if self.use_grid:
                                 heatmap_images.append(img)


### PR DESCRIPTION
I think it makes more sense to save the heat maps to a subfolder
this makes the output directory much cleaner
the heat maps are also easier to view afterwardsm as they are all nicely group in the same folder

it might be a good idea to add a toggle for this, if someone wants the image to be in the same folder

note: I haven't done extensive testing with all the other options
but considering this is a minor change thet should be bugs that are caused from this